### PR TITLE
Add the initial version of the template.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,182 @@
+import json
+
+_IMAGE = open("image.txt", "r").read().strip()
+
+def generate_config(context):
+    zone = context.properties["zone"]
+    region = zone.rsplit("-", 1)[0]
+    deployment = context.env["deployment"]
+    network_name = deployment + "-network"
+    ip_name = deployment + "-ip"
+    os_disk_name = deployment + "-os"
+    data_disk_name = deployment + "-data"
+    return {
+        "resources": [
+            # Network
+            {
+                "name": deployment + "-network",
+                "type": "compute.v1.network",
+                "properties": {
+                    "autoCreateSubnetworks": True,
+                },
+            },
+            # Firewall Rules for Controller
+            {
+                "name": deployment + "-controller",
+                "type": "compute.v1.firewall",
+                "properties": {
+                    "network": "$(ref." + network_name + ".selfLink)",
+                    "targetTags": [
+                        "lgtm-controller",
+                    ],
+                    "allowed": [
+                        {
+                            "IPProtocol": "tcp",
+                            "ports": [
+                                22, # Administrative SSH access to the virtual machine.
+                                80, # HTTP access for LGTM Enterprise's web interface.
+                                443, # HTTPS access for LGTM Enterprise's web interface.
+                                8000, # HTTP access for LGTM Enterprise's startup log.
+                            ],
+                        },
+                    ],
+                },
+            },
+            # Firewall Rules for Workers
+            {
+                "name": deployment + "-workers",
+                "type": "compute.v1.firewall",
+                "properties": {
+                    "network": "$(ref." + network_name + ".selfLink)",
+                    "targetTags": [
+                        "lgtm-worker",
+                    ],
+                    "allowed": [
+                        {
+                            "IPProtocol": "tcp",
+                            "ports": [
+                                22, # Administrative SSH access to the virtual machine.
+                                8000, # HTTP access for LGTM Enterprise's startup log.
+                            ],
+                        },
+                    ],
+                },
+            },
+            # Firewall Rule for Internal Communication
+            {
+                "name": deployment + "-internal",
+                "type": "compute.v1.firewall",
+                "properties": {
+                    "network": "$(ref." + network_name + ".selfLink)",
+                    "allowed": [
+                        {
+                            "IPProtocol": "all",
+                        },
+                    ],
+                    "sourceRanges": [
+                        "10.128.0.0/9",
+                    ],
+                },
+            },
+            # Static IP for Controller
+            {
+                "name": ip_name,
+                "type": "compute.v1.address",
+                "properties": {
+                    "region": region,
+                },
+            },
+            # OS Disk for Controller
+            {
+                "name": os_disk_name,
+                "type": "compute.v1.disk",
+                "properties": {
+                    "zone": zone,
+                    "type": "zones/" + zone + "/diskTypes/pd-ssd",
+                    "sourceImage": _IMAGE,
+                },
+            },
+            # Data Disk for Controller
+            {
+                "name": deployment + "-data",
+                "type": "compute.v1.disk",
+                "properties": {
+                    "zone": zone,
+                    "type": "zones/" + zone + "/diskTypes/pd-ssd",
+                    "sizeGb": context.properties["data-disk-size-gb"],
+                },
+            },
+            # Controller Instance
+            {
+                "name": deployment,
+                "type": "compute.v1.instance",
+                "properties": {
+                    "zone": zone,
+                    "machineType": "zones/" + zone + "/machineTypes/" + context.properties["virtual-machine-size"],
+                    "hostname": deployment + "." + zone + ".c.semmle-oss-testing.internal",
+                    "disks": [
+                        {
+                            "deviceName": "boot",
+                            "type": "PERSISTENT",
+                            "boot": True,
+                            "autoDelete": True,
+                            "source": "$(ref." + os_disk_name + ".selfLink)",
+                        },
+                        {
+                            "deviceName": "data",
+                            "type": "PERSISTENT",
+                            "autoDelete": False,
+                            "source": "$(ref." + data_disk_name + ".selfLink)",
+                        },
+                    ],
+                    "tags": {
+                        "items": [
+                            "lgtm-controller",
+                        ],
+                    },
+                    "networkInterfaces": [
+                        {
+                            "network": "$(ref." + network_name + ".selfLink)",
+                            "accessConfigs": [
+                                {
+                                    "natIP": "$(ref." + ip_name + ".address)",
+                                },
+                            ],
+                        },
+                    ],
+                    "metadata": {
+                        "items": [
+                            {
+                                "key": "admin-email",
+                                "value": context.properties["administrator-email"],
+                            },
+                            {
+                                "key": "admin-password",
+                                "value": context.properties["administrator-password"],
+                            },
+                            {
+                                "key": "n-general",
+                                "value": context.properties["general-workers"],
+                            },
+                            {
+                                "key": "n-on-demand",
+                                "value": context.properties["on-demand-workers"],
+                            },
+                            {
+                                "key": "n-query",
+                                "value": context.properties["query-workers"],
+                            },
+                            {
+                                "key": "environment",
+                                "value": json.dumps(context.properties["worker-environment"]),
+                            },
+                            {
+                                "key": "manifest-password",
+                                "value": context.properties["manifest-password"],
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+    }

--- a/controller.py
+++ b/controller.py
@@ -113,7 +113,7 @@ def generate_config(context):
                 "properties": {
                     "zone": zone,
                     "machineType": "zones/" + zone + "/machineTypes/" + context.properties["virtual-machine-size"],
-                    "hostname": deployment + "." + zone + ".c.semmle-oss-testing.internal",
+                    "hostname": deployment + "." + zone + ".c." + context.env["project"] + ".internal",
                     "disks": [
                         {
                             "deviceName": "boot",

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -90,7 +90,7 @@ properties:
       - c2-standard-16
       - c2-standard-30
       - c2-standard-60
-    description: The type of virtual machine to use.
+    description: The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
 
   data-disk-size-gb:
     type: integer

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -110,17 +110,17 @@ properties:
   general-workers:
     type: integer
     default: 1
-    description: The number of general workers to run on the controller.
+    description: The number of general workers to run on the control pool.
 
   on-demand-workers:
     type: integer
     default: 0
-    description: The number of on-demand workers to run on the controller.
+    description: The number of on-demand workers to run on the control pool.
 
   query-workers:
     type: integer
     default: 1
-    description: The number of query workers to run on the controller.
+    description: The number of query workers to run on the control pool.
 
   worker-environment:
     type: object

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -130,4 +130,4 @@ properties:
   manifest-password:
     type: string
     default: ""
-    description: A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+    description: A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -105,7 +105,7 @@ properties:
   administrator-password:
     type: string
     default: ""
-    description: The password for the initial LGTM Enterprise administrator account. It is recommended that you change this after the instance has booted.
+    description: The password for the initial LGTM Enterprise administrator account. You should change this when you log in to LGTM Enterprise.
 
   general-workers:
     type: integer

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -90,7 +90,7 @@ properties:
       - c2-standard-16
       - c2-standard-30
       - c2-standard-60
-    description: The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
+    description: The type of virtual machine to use. For information about the recommended size, see the [LGTM Enterprise installation guide](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-installation-guide.pdf).
 
   data-disk-size-gb:
     type: integer

--- a/controller.py.schema
+++ b/controller.py.schema
@@ -1,0 +1,133 @@
+info:
+  title: LGTM Enterprise Controller
+  author: GitHub
+  description: Creates an LGTM Enterprise controller.
+
+imports:
+  - path: image.txt
+  - path: controller.py
+
+properties:
+  zone:
+    type: string
+    default: us-central1-a
+    description: The Google Cloud zone to create resources in.
+
+  virtual-machine-size:
+    type: string
+    default: n2-standard-4
+    enum:
+      - e2-standard-4
+      - e2-standard-8
+      - e2-standard-16
+      - e2-highmem-2
+      - e2-highmem-4
+      - e2-highmem-8
+      - e2-highmem-16
+      - e2-highcpu-16
+      - n2-standard-4
+      - n2-standard-8
+      - n2-standard-16
+      - n2-standard-32
+      - n2-standard-48
+      - n2-standard-64
+      - n2-standard-80
+      - n2-highmem-2
+      - n2-highmem-4
+      - n2-highmem-8
+      - n2-highmem-16
+      - n2-highmem-32
+      - n2-highmem-48
+      - n2-highmem-64
+      - n2-highmem-80
+      - n2-highcpu-16
+      - n2-highcpu-32
+      - n2-highcpu-48
+      - n2-highcpu-64
+      - n2-highcpu-80
+      - n2d-standard-4
+      - n2d-standard-8
+      - n2d-standard-16
+      - n2d-standard-32
+      - n2d-standard-64
+      - n2d-standard-80
+      - n2d-standard-96
+      - n2d-standard-128
+      - n2d-standard-224
+      - n2d-highmem-2
+      - n2d-highmem-4
+      - n2d-highmem-8
+      - n2d-highmem-16
+      - n2d-highmem-32
+      - n2d-highmem-48
+      - n2d-highmem-64
+      - n2d-highmem-80
+      - n2d-highmem-96
+      - n2d-highcpu-16
+      - n2d-highcpu-32
+      - n2d-highcpu-48
+      - n2d-highcpu-64
+      - n2d-highcpu-80
+      - n2d-highcpu-96
+      - n2d-highcpu-128
+      - n2d-highcpu-224
+      - n1-standard-8
+      - n1-standard-16
+      - n1-standard-32
+      - n1-standard-64
+      - n1-standard-96
+      - n1-highmem-4
+      - n1-highmem-8
+      - n1-highmem-16
+      - n1-highmem-32
+      - n1-highmem-64
+      - n1-highmem-96
+      - n1-highcpu-32
+      - n1-highcpu-64
+      - n1-highcpu-96
+      - c2-standard-4
+      - c2-standard-8
+      - c2-standard-16
+      - c2-standard-30
+      - c2-standard-60
+    description: The type of virtual machine to use.
+
+  data-disk-size-gb:
+    type: integer
+    default: 1024
+    description: The data disk size for your LGTM Enterprise instance in gigabytes.
+
+  administrator-email:
+    type: string
+    default: ""
+    description: The email address for the initial LGTM Enterprise administrator account.
+
+  administrator-password:
+    type: string
+    default: ""
+    description: The password for the initial LGTM Enterprise administrator account. It is recommended that you change this after the instance has booted.
+
+  general-workers:
+    type: integer
+    default: 1
+    description: The number of general workers to run on the controller.
+
+  on-demand-workers:
+    type: integer
+    default: 0
+    description: The number of on-demand workers to run on the controller.
+
+  query-workers:
+    type: integer
+    default: 1
+    description: The number of query workers to run on the controller.
+
+  worker-environment:
+    type: object
+    default: {}
+    description: A dictionary of environment variables to use for the workers.
+
+  manifest-password:
+    type: string
+    default: ""
+    description: A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.

--- a/instructions.md
+++ b/instructions.md
@@ -24,7 +24,7 @@ You can use the above command by copying and pasting it, editing the values for 
 * `virtual-machine-size` - The type of virtual machine to use.
 * `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.
 * `administrator-email` - The email address for the initial LGTM Enterprise administrator account.
-* `administrator-password` - The password for the initial LGTM Enterprise administrator account. It is recommended that you change this after the instance has booted.
+* `administrator-password` - The password for the initial LGTM Enterprise administrator account. You should change this when you log in to LGTM Enterprise.
 * `general-workers` - The number of general workers to run on the control pool.
 * `on-demand-workers` - The number of on-demand workers to run on the control pool.
 * `query-workers` - The number of query workers to run on the control pool.

--- a/instructions.md
+++ b/instructions.md
@@ -2,6 +2,7 @@
 ## Preparation
 Throughout this setup guide a few variables are used that are useful to set in advance. Set the Google Cloud project you want to deploy to, the zone to create any zonal resources in and a unique name for this deployment. If you are upgrading an existing installation, set these values to the same values used when LGTM was first set up.
 
+Using the Cloud Shell command line, set values for the `project`, `zone` and `deployment` variables. For example:
 ```console
 project="my-project"
 zone="us-central1-a"

--- a/instructions.md
+++ b/instructions.md
@@ -21,7 +21,7 @@ gcloud deployment-manager deployments create --project "$project" --template=con
 
 You can use the above command by copying and pasting it, editing the values for the initial administrator email and password. If you want to further customize your deployment, additional options can be added to the `--properties` flag:
 * `zone` - The Google Cloud zone to create resources in.
-* `virtual-machine-size` - The type of virtual machine to use.
+* `virtual-machine-size` - The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
 * `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.
 * `administrator-email` - The email address for the initial LGTM Enterprise administrator account.
 * `administrator-password` - The password for the initial LGTM Enterprise administrator account. You should change this when you log in to LGTM Enterprise.
@@ -71,7 +71,7 @@ You can use the above command by copying and pasting it. If you want to customiz
 * `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool that this worker group should connect to.
 * `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise control pool.
 * `zone` - The Google Cloud zone to create resources in.
-* `virtual-machine-size` - The type of virtual machine to use.
+* `virtual-machine-size` - The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
 * `copies` - The number of copies of this worker to create.
 * `general-workers` - The number of general workers to run on each machine in the group.
 * `on-demand-workers` - The number of on-demand workers to run on each machine in the group.

--- a/instructions.md
+++ b/instructions.md
@@ -21,7 +21,7 @@ gcloud deployment-manager deployments create --project "$project" --template=con
 
 You can use the above command by copying and pasting it, editing the values for the initial administrator email and password. If you want to further customize your deployment, additional options can be added to the `--properties` flag:
 * `zone` - The Google Cloud zone to create resources in.
-* `virtual-machine-size` - The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
+* `virtual-machine-size` - The type of virtual machine to use. For information about the recommended size, see the [LGTM Enterprise installation guide](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-installation-guide.pdf).
 * `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.
 * `administrator-email` - The email address for the initial LGTM Enterprise administrator account.
 * `administrator-password` - The password for the initial LGTM Enterprise administrator account. You should change this when you log in to LGTM Enterprise.
@@ -73,7 +73,7 @@ You can use the above command by copying and pasting it. If you want to customiz
 * `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool that this worker group should connect to.
 * `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise control pool.
 * `zone` - The Google Cloud zone to create resources in.
-* `virtual-machine-size` - The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
+* `virtual-machine-size` - The type of virtual machine to use. For information about the recommended size, see the [LGTM Enterprise installation guide](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-installation-guide.pdf).
 * `copies` - The number of copies of this worker to create.
 * `general-workers` - The number of general workers to run on each machine in the group.
 * `on-demand-workers` - The number of on-demand workers to run on each machine in the group.

--- a/instructions.md
+++ b/instructions.md
@@ -67,7 +67,7 @@ gcloud deployment-manager deployments create --project "$project" --template=wor
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"
 ```
 
-The `--properties` flag can be used to provide a variety of options to customize your deployment:
+You can use the above command by copying and pasting it. If you want to customize your deployment, you can add more settings to the `--properties` flag:
 * `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool deployment that this worker group should connect to.
 * `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise control pool.
 * `zone` - The Google Cloud zone to create resources in.

--- a/instructions.md
+++ b/instructions.md
@@ -31,7 +31,7 @@ You can use the above command by copying and pasting it, editing the values for 
 * `worker-environment` - A JSON dictionary of environment variables to use for the workers.
 * `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
-### Upgrading an Existing LGTM Enterprise Control Pool
+### Upgrading the LGTM Enterprise control pool
 When upgrading, it is important that you use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
 ```
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment" --format "value(manifest)")"

--- a/instructions.md
+++ b/instructions.md
@@ -55,6 +55,8 @@ gcloud deployment-manager deployments create --project "$project" --template con
 ## Workers
 Workers are managed as instance groups. All workers in an instance group are provisioned identically and groups can be scaled up and down depending on your needs. Decide a name for your worker group, or if you are upgrading an existing group use the same name you used to create the group.
 
+Set the worker_credentials value by copying and pasting from the _Infrastructure > Worker management_ tab of the LGTM administration interface.
+
 ```console
 worker_group="workers"
 worker_credentials='worker-credentials: "H4sIAAAAAAAAAI...=="'

--- a/instructions.md
+++ b/instructions.md
@@ -87,3 +87,8 @@ The controller can then be upgraded by re-deploying the template. If you specifi
 gcloud deployment-manager deployments update --project "$project" --template worker.py "$deployment-$worker_group" \
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"
 ```
+
+## Finish
+That's it. LGTM Enterprise should now be installed or upgraded. Click _Finish_ below to close this tutorial.
+
+If you need to open it again, you can always find the link to do so on the [LGTM Enterprise releases page](https://github.com/Semmle/lgtm-enterprise/releases/).

--- a/instructions.md
+++ b/instructions.md
@@ -4,8 +4,8 @@ Throughout this setup guide a few variables are used that are useful to set in a
 
 ```console
 project="my-project"
-deployment="lgtm"
 zone="us-central1-a"
+deployment="lgtm"
 ```
 
 ## Controller

--- a/instructions.md
+++ b/instructions.md
@@ -31,6 +31,11 @@ You can use the above command by copying and pasting it, editing the values for 
 * `worker-environment` - A JSON dictionary of environment variables to use for the workers.
 * `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
+You can obtain the IP address of the created LGTM Enterprise instance by running:
+```
+gcloud compute instances list --project "$project" --filter "name=$deployment"
+```
+
 ### Upgrading the LGTM Enterprise control pool
 When upgrading, you must use the same properties you used when you first deployed LGTM. You can see the properties you used previously by running:
 ```

--- a/instructions.md
+++ b/instructions.md
@@ -13,7 +13,7 @@ After you have done this, click _Start_ to to find out how to create or upgrade 
 
 ## Control pool
 ### Creating a new LGTM Enterprise control pool
-A new LGTM Enterprise control pool can be created using the `controller.py` template.
+You can create a new LGTM Enterprise control pool machine by using the `controller.py` template.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template=controller.py "$deployment" \
 	--properties "zone:$zone,administrator-email:email@example.com,administrator-password:MySuperSecretPassword"

--- a/instructions.md
+++ b/instructions.md
@@ -85,7 +85,7 @@ When upgrading, you will probably want to use the same properties as when you fi
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"
 ```
 
-The control pool can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+You can now upgrade the worker group by redeploying the template. If you specified any properties when the instance was first created, provide them again here.
 ```console
 gcloud deployment-manager deployments update --project "$project" --template worker.py "$deployment-$worker_group" \
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"

--- a/instructions.md
+++ b/instructions.md
@@ -80,7 +80,7 @@ You can use the above command by copying and pasting it. If you want to customiz
 * `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
 ### Upgrading an LGTM Enterprise worker group
-When upgrading, you likely want to use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
+When upgrading, you will probably want to use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
 ```
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"
 ```

--- a/instructions.md
+++ b/instructions.md
@@ -1,6 +1,6 @@
 # Installing LGTM Enterprise on Google Cloud
 ## Preparation
-Throughout this setup guide a few variables are used that are useful to set in advance. Set the Google Cloud project you want to deploy to, the zone to create any zonal resources in and a unique name for this deployment. If you are upgrading an existing installation, set these values to the same values used when LGTM was first set up.
+Throughout this setup guide a few variables are used that are useful to set in advance. Specify an existing Google Cloud project that you want to deploy to, the zone to create any zonal resources in and a unique name of your choice for this deployment. If you are upgrading an existing installation, set these values to the same values used when LGTM was first set up.
 
 Using the Cloud Shell command line, set values for the `project`, `zone` and `deployment` variables. For example:
 ```console

--- a/instructions.md
+++ b/instructions.md
@@ -47,7 +47,7 @@ Next the deployment must be removed, abandoning, but not removing the old resour
 gcloud deployment-manager deployments delete --project "$project" --delete-policy abandon "$deployment"
 ```
 
-The control pool can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+You can now upgrade the control pool by redeploying the template. If you specified any properties when the instance was first created, provide them again here.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template controller.py --properties zone:$zone "$deployment"
 ```

--- a/instructions.md
+++ b/instructions.md
@@ -68,7 +68,7 @@ gcloud deployment-manager deployments create --project "$project" --template=wor
 ```
 
 You can use the above command by copying and pasting it. If you want to customize your deployment, you can add more settings to the `--properties` flag:
-* `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool deployment that this worker group should connect to.
+* `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool that this worker group should connect to.
 * `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise control pool.
 * `zone` - The Google Cloud zone to create resources in.
 * `virtual-machine-size` - The type of virtual machine to use.

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,89 @@
+# Installing LGTM Enterprise on Google Cloud
+## Preparation
+Throughout this setup guide a few variables are used that are useful to set in advance. Set the Google Cloud project you want to deploy to, the zone to create any zonal resources in and a unique name for this deployment. If you are upgrading an existing installation, set these values to the same values used when LGTM was first set up.
+
+```console
+project="my-project"
+deployment="lgtm"
+zone="us-central1-a"
+```
+
+## Controller
+### Creating a New LGTM Enterprise Controller
+A new LGTM Enterprise controller machine can be created using the `controller.py` template.
+```console
+gcloud deployment-manager deployments create --project "$project" --template=controller.py "$deployment" \
+	--properties "zone:$zone,administrator-email:email@example.com,administrator-password:MySuperSecretPassword"
+```
+
+The `--properties` flag can be used to provide a variety of options to customize your deployment:
+* `zone` - The Google Cloud zone to create resources in.
+* `virtual-machine-size` - The type of virtual machine to use.
+* `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.
+* `administrator-email` - The email address for the initial LGTM Enterprise administrator account.
+* `administrator-password` - The password for the initial LGTM Enterprise administrator account. It is recommended that you change this after the instance has booted.
+* `general-workers` - The number of general workers to run on the controller.
+* `on-demand-workers` - The number of on-demand workers to run on the controller.
+* `query-workers` - The number of query workers to run on the controller.
+* `worker-environment` - A JSON dictionary of environment variables to use for the workers.
+* `manifest-password` - A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+
+### Upgrading an Existing LGTM Enterprise Controller
+When upgrading, it is important that you use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
+```
+gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment" --format "value(manifest)")"
+```
+
+To update an existing LGTM Enterprise controller the old virtual machine and OS disk must be removed.
+```
+gcloud compute instances delete --project "$project" --zone "$zone" "$deployment" --keep-disks data
+```
+
+Next the deployment must be removed, abandoning, but not removing the old resources.
+```
+gcloud deployment-manager deployments delete --project "$project" --delete-policy abandon "$deployment"
+```
+
+The controller can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+```console
+gcloud deployment-manager deployments create --project "$project" --template controller.py --properties zone:$zone "$deployment"
+```
+
+## Workers
+Workers are managed as instance groups. All workers in an instance group are provisioned identically and groups can be scaled up and down depending on your needs. Decide a name for your worker group, or if you are upgrading an existing group use the same name you used to create the group.
+
+```console
+worker_group="workers"
+worker_credentials='worker-credentials: "H4sIAAAAAAAAAI...=="'
+```
+
+### Creating a New LGTM Enterprise Worker Group
+A new LGTM Enterprise worker group can be created using the `worker.py` template.
+```console
+gcloud deployment-manager deployments create --project "$project" --template=worker.py "$deployment-$worker_group" \
+	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"
+```
+
+The `--properties` flag can be used to provide a variety of options to customize your deployment:
+* `controller-deployment-name` - The deployment name for the LGTM Enterprise controller deployment that this worker group should connect to.
+* `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise controller.
+* `zone` - The Google Cloud zone to create resources in.
+* `virtual-machine-size` - The type of virtual machine to use.
+* `copies` - The number of copies of this worker to create.
+* `general-workers` - The number of general workers to run on each machine in the group.
+* `on-demand-workers` - The number of on-demand workers to run on each machine in the group.
+* `query-workers` - The number of query workers to run on each machine in the group.
+* `worker-environment` - A dictionary of environment variables to use for the workers.
+* `manifest-password` - A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+
+### Upgrading an Existing LGTM Enterprise Worker Group
+When upgrading, you likely want to use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
+```
+gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"
+```
+
+The controller can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+```console
+gcloud deployment-manager deployments update --project "$project" --template worker.py "$deployment-$worker_group" \
+	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"
+```

--- a/instructions.md
+++ b/instructions.md
@@ -11,9 +11,9 @@ deployment="lgtm"
 
 After you have done this, click _Start_ to to find out how to create or upgrade a control pool (step 1), or create or upgrade a worker group (step 2).
 
-## Controller
-### Creating a New LGTM Enterprise Controller
-A new LGTM Enterprise controller machine can be created using the `controller.py` template.
+## Control pool
+### Creating a new LGTM Enterprise control pool
+A new LGTM Enterprise control pool can be created using the `controller.py` template.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template=controller.py "$deployment" \
 	--properties "zone:$zone,administrator-email:email@example.com,administrator-password:MySuperSecretPassword"
@@ -25,19 +25,19 @@ The `--properties` flag can be used to provide a variety of options to customize
 * `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.
 * `administrator-email` - The email address for the initial LGTM Enterprise administrator account.
 * `administrator-password` - The password for the initial LGTM Enterprise administrator account. It is recommended that you change this after the instance has booted.
-* `general-workers` - The number of general workers to run on the controller.
-* `on-demand-workers` - The number of on-demand workers to run on the controller.
-* `query-workers` - The number of query workers to run on the controller.
+* `general-workers` - The number of general workers to run on the control pool.
+* `on-demand-workers` - The number of on-demand workers to run on the control pool.
+* `query-workers` - The number of query workers to run on the control pool.
 * `worker-environment` - A JSON dictionary of environment variables to use for the workers.
 * `manifest-password` - A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
-### Upgrading an Existing LGTM Enterprise Controller
+### Upgrading an Existing LGTM Enterprise Control Pool
 When upgrading, it is important that you use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
 ```
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment" --format "value(manifest)")"
 ```
 
-To update an existing LGTM Enterprise controller the old virtual machine and OS disk must be removed.
+To update an existing LGTM Enterprise control pool the old virtual machine and OS disk must be removed.
 ```
 gcloud compute instances delete --project "$project" --zone "$zone" "$deployment" --keep-disks data
 ```
@@ -47,7 +47,7 @@ Next the deployment must be removed, abandoning, but not removing the old resour
 gcloud deployment-manager deployments delete --project "$project" --delete-policy abandon "$deployment"
 ```
 
-The controller can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+The control pool can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template controller.py --properties zone:$zone "$deployment"
 ```
@@ -68,8 +68,8 @@ gcloud deployment-manager deployments create --project "$project" --template=wor
 ```
 
 The `--properties` flag can be used to provide a variety of options to customize your deployment:
-* `controller-deployment-name` - The deployment name for the LGTM Enterprise controller deployment that this worker group should connect to.
-* `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise controller.
+* `controller-deployment-name` - The deployment name for the LGTM Enterprise control pool deployment that this worker group should connect to.
+* `worker-credentials` - This should be copied from the administrator interface of the LGTM Enterprise control pool.
 * `zone` - The Google Cloud zone to create resources in.
 * `virtual-machine-size` - The type of virtual machine to use.
 * `copies` - The number of copies of this worker to create.
@@ -85,7 +85,7 @@ When upgrading, you likely want to use the same properties as when you first dep
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"
 ```
 
-The controller can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
+The control pool can then be upgraded by re-deploying the template. If you specified any properties when the instance was first created, provide them again here.
 ```console
 gcloud deployment-manager deployments update --project "$project" --template worker.py "$deployment-$worker_group" \
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"

--- a/instructions.md
+++ b/instructions.md
@@ -19,7 +19,7 @@ gcloud deployment-manager deployments create --project "$project" --template=con
 	--properties "zone:$zone,administrator-email:email@example.com,administrator-password:MySuperSecretPassword"
 ```
 
-The `--properties` flag can be used to provide a variety of options to customize your deployment:
+You can use the above command by copying and pasting it, editing the values for the initial administrator email and password. If you want to further customize your deployment, additional options can be added to the `--properties` flag:
 * `zone` - The Google Cloud zone to create resources in.
 * `virtual-machine-size` - The type of virtual machine to use.
 * `data-disk-size-gb` - The data disk size for your LGTM Enterprise instance in gigabytes.

--- a/instructions.md
+++ b/instructions.md
@@ -60,7 +60,7 @@ worker_group="workers"
 worker_credentials='worker-credentials: "H4sIAAAAAAAAAI...=="'
 ```
 
-### Creating a New LGTM Enterprise Worker Group
+### Creating a new LGTM Enterprise worker group
 A new LGTM Enterprise worker group can be created using the `worker.py` template.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template=worker.py "$deployment-$worker_group" \
@@ -79,7 +79,7 @@ The `--properties` flag can be used to provide a variety of options to customize
 * `worker-environment` - A dictionary of environment variables to use for the workers.
 * `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
-### Upgrading an Existing LGTM Enterprise Worker Group
+### Upgrading an LGTM Enterprise worker group
 When upgrading, you likely want to use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
 ```
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"

--- a/instructions.md
+++ b/instructions.md
@@ -29,7 +29,7 @@ You can use the above command by copying and pasting it, editing the values for 
 * `on-demand-workers` - The number of on-demand workers to run on the control pool.
 * `query-workers` - The number of query workers to run on the control pool.
 * `worker-environment` - A JSON dictionary of environment variables to use for the workers.
-* `manifest-password` - A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+* `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
 ### Upgrading an Existing LGTM Enterprise Control Pool
 When upgrading, it is important that you use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
@@ -77,7 +77,7 @@ The `--properties` flag can be used to provide a variety of options to customize
 * `on-demand-workers` - The number of on-demand workers to run on each machine in the group.
 * `query-workers` - The number of query workers to run on each machine in the group.
 * `worker-environment` - A dictionary of environment variables to use for the workers.
-* `manifest-password` - A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+* `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
 ### Upgrading an Existing LGTM Enterprise Worker Group
 When upgrading, you likely want to use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:

--- a/instructions.md
+++ b/instructions.md
@@ -9,6 +9,8 @@ zone="us-central1-a"
 deployment="lgtm"
 ```
 
+After you have done this, click _Start_ to to find out how to create or upgrade a control pool (step 1), or create or upgrade a worker group (step 2).
+
 ## Controller
 ### Creating a New LGTM Enterprise Controller
 A new LGTM Enterprise controller machine can be created using the `controller.py` template.

--- a/instructions.md
+++ b/instructions.md
@@ -32,7 +32,7 @@ You can use the above command by copying and pasting it, editing the values for 
 * `manifest-password` - A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
 
 ### Upgrading the LGTM Enterprise control pool
-When upgrading, it is important that you use the same properties as when you first deployed LGTM. You can see the properties you used previously by running:
+When upgrading, you must use the same properties you used when you first deployed LGTM. You can see the properties you used previously by running:
 ```
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment" --format "value(manifest)")"
 ```

--- a/instructions.md
+++ b/instructions.md
@@ -61,7 +61,7 @@ worker_credentials='worker-credentials: "H4sIAAAAAAAAAI...=="'
 ```
 
 ### Creating a new LGTM Enterprise worker group
-A new LGTM Enterprise worker group can be created using the `worker.py` template.
+You can create a new LGTM Enterprise worker group by using the `worker.py` template.
 ```console
 gcloud deployment-manager deployments create --project "$project" --template=worker.py "$deployment-$worker_group" \
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,97 @@
+import json
+
+_IMAGE = open("image.txt", "r").read().strip()
+
+def generate_config(context):
+    zone = context.properties["zone"]
+    region = zone.rsplit("-", 1)[0]
+    controller_deployment = context.properties["controller-deployment-name"]
+    deployment = context.env["deployment"]
+    network_name = controller_deployment + "-network"
+    instance_template_name = deployment + "-template"
+    instance_group_manager_name = deployment + "-group"
+    return {
+        "resources": [
+            # Worker Group Instance Template
+            {
+                "name": instance_template_name,
+                "type": "compute.v1.instanceTemplate",
+                "properties": {
+                    "properties": {
+                        "zone": zone,
+                        "machineType": context.properties["virtual-machine-size"],
+                        "disks": [
+                            {
+                                "deviceName": "boot",
+                                "type": "PERSISTENT",
+                                "boot": True,
+                                "autoDelete": True,
+                                "initializeParams": {
+                                    "diskType": "pd-ssd",
+                                    "sourceImage": _IMAGE,
+                                },
+                            },
+                        ],
+                        "tags": {
+                            "items": [
+                                "lgtm-worker",
+                            ],
+                        },
+                        "networkInterfaces": [
+                            {
+                                "network": "projects/" + context.env["project"] + "/global/networks/" + network_name,
+                                "accessConfigs": [
+                                    {
+                                        "type": "ONE_TO_ONE_NAT",
+                                    },
+                                ],
+                            },
+                        ],
+                        "metadata": {
+                            "items": [
+                                {
+                                    "key": "controller-hostname",
+                                    "value": controller_deployment + "." + zone + ".c." + context.env["project"] + ".internal",
+                                },
+                                {
+                                    "key": "worker-credentials",
+                                    "value": context.properties["worker-credentials"],
+                                },
+                                {
+                                    "key": "n-general",
+                                    "value": context.properties["general-workers"],
+                                },
+                                {
+                                    "key": "n-on-demand",
+                                    "value": context.properties["on-demand-workers"],
+                                },
+                                {
+                                    "key": "n-query",
+                                    "value": context.properties["query-workers"],
+                                },
+                                {
+                                    "key": "environment",
+                                    "value": json.dumps(context.properties["worker-environment"]),
+                                },
+                                {
+                                    "key": "manifest-password",
+                                    "value": context.properties["manifest-password"],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+            # Worker Group Instance Group Manager
+            {
+                "name": instance_group_manager_name,
+                "type": "compute.v1.instanceGroupManager",
+                "properties": {
+                    "zone": zone,
+                    "baseInstanceName": deployment,
+                    "instanceTemplate": "$(ref." + instance_template_name + ".selfLink)",
+                    "targetSize": 1,
+                },
+            },
+        ],
+    }

--- a/worker.py
+++ b/worker.py
@@ -90,7 +90,7 @@ def generate_config(context):
                     "zone": zone,
                     "baseInstanceName": deployment,
                     "instanceTemplate": "$(ref." + instance_template_name + ".selfLink)",
-                    "targetSize": 1,
+                    "targetSize": context.properties["copies"],
                 },
             },
         ],

--- a/worker.py.schema
+++ b/worker.py.schema
@@ -117,7 +117,7 @@ properties:
       - c2-standard-16
       - c2-standard-30
       - c2-standard-60
-    description: The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
+    description: The type of virtual machine to use. For information about the recommended size, see the [LGTM Enterprise installation guide](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-installation-guide.pdf).
 
   copies:
     type: integer

--- a/worker.py.schema
+++ b/worker.py.schema
@@ -117,7 +117,7 @@ properties:
       - c2-standard-16
       - c2-standard-30
       - c2-standard-60
-    description: The type of virtual machine to use.
+    description: The type of virtual machine to use. For information about the minimum recommended size, see the [LGTM Enterprise system requirements document](https://help.semmle.com/lgtm-enterprise/ops/lgtm-enterprise-LATEST-system-requirements.pdf).
 
   copies:
     type: integer

--- a/worker.py.schema
+++ b/worker.py.schema
@@ -1,0 +1,150 @@
+info:
+  title: LGTM Enterprise Worker Group
+  author: GitHub
+  description: Creates an LGTM Enterprise worker group.
+
+imports:
+  - path: image.txt
+  - path: worker.py
+
+required:
+  - controller-deployment-name
+  - worker-credentials
+
+properties:
+  controller-deployment-name:
+    type: string
+    description: The deployment name for the LGTM Enterprise controller deployment that this worker group should connect to.
+
+  worker-credentials:
+    type: string
+    default: ""
+    description: This should be copied from the administrator interface of the LGTM Enterprise controller.
+
+  zone:
+    type: string
+    default: us-central1-a
+    description: The Google Cloud zone to create resources in.
+
+  virtual-machine-size:
+    type: string
+    default: n2-standard-2
+    enum:
+      - e2-standard-2
+      - e2-standard-4
+      - e2-standard-8
+      - e2-standard-16
+      - e2-highmem-2
+      - e2-highmem-4
+      - e2-highmem-8
+      - e2-highmem-16
+      - e2-highcpu-4
+      - e2-highcpu-8
+      - e2-highcpu-16
+      - n2-standard-2
+      - n2-standard-4
+      - n2-standard-8
+      - n2-standard-16
+      - n2-standard-32
+      - n2-standard-48
+      - n2-standard-64
+      - n2-standard-80
+      - n2-highmem-2
+      - n2-highmem-4
+      - n2-highmem-8
+      - n2-highmem-16
+      - n2-highmem-32
+      - n2-highmem-48
+      - n2-highmem-64
+      - n2-highmem-80
+      - n2-highcpu-4
+      - n2-highcpu-8
+      - n2-highcpu-16
+      - n2-highcpu-32
+      - n2-highcpu-48
+      - n2-highcpu-64
+      - n2-highcpu-80
+      - n2d-standard-2
+      - n2d-standard-4
+      - n2d-standard-8
+      - n2d-standard-16
+      - n2d-standard-32
+      - n2d-standard-64
+      - n2d-standard-80
+      - n2d-standard-96
+      - n2d-standard-128
+      - n2d-standard-224
+      - n2d-highmem-2
+      - n2d-highmem-4
+      - n2d-highmem-8
+      - n2d-highmem-16
+      - n2d-highmem-32
+      - n2d-highmem-48
+      - n2d-highmem-64
+      - n2d-highmem-80
+      - n2d-highmem-96
+      - n2d-highcpu-4
+      - n2d-highcpu-8
+      - n2d-highcpu-16
+      - n2d-highcpu-32
+      - n2d-highcpu-48
+      - n2d-highcpu-64
+      - n2d-highcpu-80
+      - n2d-highcpu-96
+      - n2d-highcpu-128
+      - n2d-highcpu-224
+      - n1-standard-2
+      - n1-standard-4
+      - n1-standard-8
+      - n1-standard-16
+      - n1-standard-32
+      - n1-standard-64
+      - n1-standard-96
+      - n1-highmem-2
+      - n1-highmem-4
+      - n1-highmem-8
+      - n1-highmem-16
+      - n1-highmem-32
+      - n1-highmem-64
+      - n1-highmem-96
+      - n1-highcpu-8
+      - n1-highcpu-16
+      - n1-highcpu-32
+      - n1-highcpu-64
+      - n1-highcpu-96
+      - c2-standard-4
+      - c2-standard-8
+      - c2-standard-16
+      - c2-standard-30
+      - c2-standard-60
+    description: The type of virtual machine to use.
+
+  copies:
+    type: integer
+    default: 1
+    description: The number of copies of this worker to create.
+
+  general-workers:
+    type: integer
+    default: 1
+    description: The number of general workers to run on each machine in the group.
+
+  on-demand-workers:
+    type: integer
+    default: 0
+    description: The number of on-demand workers to run on each machine in the group.
+
+  query-workers:
+    type: integer
+    default: 1
+    description: The number of query workers to run on each machine in the group.
+
+  worker-environment:
+    type: object
+    default: {}
+    description: A dictionary of environment variables to use for the workers.
+
+  manifest-password:
+    type: string
+    default: ""
+    description: A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.

--- a/worker.py.schema
+++ b/worker.py.schema
@@ -147,4 +147,4 @@ properties:
   manifest-password:
     type: string
     default: ""
-    description: A password used to encrypt the LGTM manifest. If not specified a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.
+    description: A password used to encrypt the LGTM manifest. If you don't specify one a password will be generated and stored in `/data/lgtm-releases/.manifest-password`.


### PR DESCRIPTION
This adds Google Deployment Manager templates for deploying LGTM Enterprise on Google Cloud.

There is one template for deploying the LGTM Enterprise controller, and another for deploying groups of workers. There is also a Google Cloud Shell tutorial markdown document to guide users through the process of deploying or upgrading LGTM Enterprise.

Both templates look for an `image.txt` file to decide which image to use, though this is not currently present; it will be added to the repository when we release the next version of LGTM Enterprise.

We could likely make this simpler to use by providing some scripts that wrap `gcloud` to make the installation and upgrade process simpler, but for now I've just documented the manual steps required.