### PR TITLE
Fix worker updating.

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -92,10 +92,11 @@ When upgrading, you will probably want to use the same properties as when you fi
 gcloud deployment-manager manifests describe --project "$project" --deployment "$deployment-$worker_group" --format "value(config.content)" "$(gcloud deployment-manager deployments list --project "$project" --filter "name=$deployment-$worker_group" --format "value(manifest)")"
 ```
 
-You can now upgrade the worker group by redeploying the template. If you specified any properties when the instance was first created, provide them again here.
+You can now upgrade the worker group by redeploying the template and recreating the instances. If you specified any properties when the instance was first created, provide them again here.
 ```console
 gcloud deployment-manager deployments update --project "$project" --template worker.py "$deployment-$worker_group" \
 	--properties "zone:$zone,controller-deployment-name:$deployment,$worker_credentials"
+gcloud compute instance-groups managed rolling-action replace --project "$project" --zone "$zone" "$deployment-$worker_group-group" --max-surge 0 --max-unavailable 100%
 ```
 
 ## Finish

--- a/worker.py
+++ b/worker.py
@@ -1,4 +1,6 @@
 import json
+import random
+import string
 
 _IMAGE = open("image.txt", "r").read().strip()
 
@@ -8,7 +10,8 @@ def generate_config(context):
     controller_deployment = context.properties["controller-deployment-name"]
     deployment = context.env["deployment"]
     network_name = controller_deployment + "-network"
-    instance_template_name = deployment + "-template"
+    instance_template_id = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(4))
+    instance_template_name = deployment + "-template-" + instance_template_id
     instance_group_manager_name = deployment + "-group"
     return {
         "resources": [


### PR DESCRIPTION
This fixes an issue where upgrading the LGTM worker version would fail because instance templates are immutable.

To fix this I've made it so every time you deploy a new instance template is created with a random name. I've also added a step to tell the instance group to replace all the instances. This should have been possible to do automatically by applying a proactive update policy to the instance group manager, but there seems to be a bug in Google Deployment Manager that prevents this from working.